### PR TITLE
Update RatePlans-OTA_HotelRatePlanNotifRQ.xml

### DIFF
--- a/files/samples/RatePlans-OTA_HotelRatePlanNotifRQ.xml
+++ b/files/samples/RatePlans-OTA_HotelRatePlanNotifRQ.xml
@@ -48,8 +48,8 @@
                 <Rate InvTypeCode="double" Start="2014-03-03" End="2014-03-08">
 
                     <BaseByGuestAmts>
-                        <BaseByGuestAmt Type="25" NumberOfGuests="1" AgeQualifyingCode="10" AmountAfterTax="106"/>
-                        <BaseByGuestAmt Type="25" NumberOfGuests="2" AgeQualifyingCode="10" AmountAfterTax="192"/>
+                        <BaseByGuestAmt Type="7" NumberOfGuests="1" AgeQualifyingCode="10" AmountAfterTax="106"/>
+                        <BaseByGuestAmt Type="7" NumberOfGuests="2" AgeQualifyingCode="10" AmountAfterTax="96"/>
                     </BaseByGuestAmts>
                     <AdditionalGuestAmounts>
                         <AdditionalGuestAmount AgeQualifyingCode="10" Amount="76.8"/>


### PR DESCRIPTION
This fixes the issue of the misbehaving usage of Type 7 in a way which is the opposite of d60ce12332db22fe939c75a7276434d1b4c978f5 (adapt the price, instead of the type).

I believe this is better because otherwise the example lacks completeness.