### PR TITLE
Support supplement PrerequisiteInventory

### DIFF
--- a/files/samples-contrib/RatePlans-full-supplements-New.xml
+++ b/files/samples-contrib/RatePlans-full-supplements-New.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<OTA_HotelRatePlanNotifRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns="http://www.opentravel.org/OTA/2003/05"
+                          xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanNotifRQ.xsd"
+                          Version="1.000">
+
+    <RatePlans HotelCode="123" HotelName="Frangart Inn">
+
+        <RatePlan RatePlanNotifType="New" CurrencyCode="EUR" RatePlanCode="Rate1-4-HB">
+
+            <BookingRules>
+
+                <BookingRule Start="2014-03-03" End="2014-04-17">
+
+                    <LengthsOfStay>
+                        <LengthOfStay Time="5" TimeUnit="Day" MinMaxMessageType="SetMinLOS"/>
+                        <LengthOfStay Time="5" TimeUnit="Day" MinMaxMessageType="SetMaxLOS"/>
+                    </LengthsOfStay>
+
+                    <DOW_Restrictions>
+                        <ArrivalDaysOfWeek   Mon="1" Tue="1" Weds="1" Thur="1" Fri="1" Sat="1" Sun="1"/>
+                        <DepartureDaysOfWeek Mon="1" Tue="1" Weds="1" Thur="1" Fri="1" Sat="1" Sun="1"/>
+                    </DOW_Restrictions>
+
+                    <RestrictionStatus Restriction="Master" Status="Open"/>
+
+                </BookingRule>
+
+            </BookingRules>
+
+            <Rates>
+
+                <!-- first in list: the static rate - values apply to every rate in the rate plan -->
+
+                <Rate RateTimeUnit="Day" UnitMultiplier="1">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt Type="7"/>
+                    </BaseByGuestAmts>
+                    <MealsIncluded MealPlanIndicator="true" MealPlanCodes="12"/>
+                </Rate>
+
+                <!-- following: "normal" rates ... -->
+
+                <Rate InvTypeCode="double" Start="2014-03-03" End="2014-03-08">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt NumberOfGuests="1" AgeQualifyingCode="10" AmountAfterTax="106"/>
+                        <BaseByGuestAmt NumberOfGuests="2" AgeQualifyingCode="10" AmountAfterTax="96"/>
+                    </BaseByGuestAmts>
+                    <AdditionalGuestAmounts>
+                        <AdditionalGuestAmount AgeQualifyingCode="10" Amount="76.8"/>
+                        <AdditionalGuestAmount AgeQualifyingCode="8"              MaxAge="3" Amount="0"    />
+                        <AdditionalGuestAmount AgeQualifyingCode="8"  MinAge="3"  MaxAge="6" Amount="38.4" />
+                        <AdditionalGuestAmount AgeQualifyingCode="8"  MinAge="6"  MaxAge="10" Amount="48"  />
+                        <AdditionalGuestAmount AgeQualifyingCode="8"  MinAge="10" MaxAge="16" Amount="67.2"/>
+                    </AdditionalGuestAmounts>
+                </Rate>
+
+            </Rates>
+
+            <Supplements>
+
+                <Supplement InvType="EXTRA" InvCode="0x539" AddToBasicRateIndicator="true" MandatoryIndicator="true" ChargeTypeCode="18">
+                    <Description Name="title">
+                        <Text TextFormat="PlainText" Language="de">Endreinigung</Text>
+                        <Text TextFormat="PlainText" Language="it">Pulizia finale</Text>
+
+                    </Description>
+                    <Description Name="intro">
+                        <Text TextFormat="PlainText" Language="de">Die Endreinigung lorem ipsum dolor sit amet.</Text>
+                        <Text TextFormat="PlainText" Language="it">La pulizia finale lorem ipsum dolor sit amet.</Text>
+                    </Description>
+                </Supplement>
+                <Supplement InvType="EXTRA" InvCode="0x540" AddToBasicRateIndicator="true" MandatoryIndicator="false" ChargeTypeCode="18">
+                    <PrerequisiteInventory InvCode="0000001" InvType="ALPINEBITSDOW"/>
+                    <Description Name="title">
+                        <Text TextFormat="PlainText" Language="de">Title Supplement 0x540 DE</Text>
+                        <Text TextFormat="PlainText" Language="it">Title Supplement 0x540 IT</Text>
+
+                    </Description>
+                    <Description Name="intro">
+                        <Text TextFormat="PlainText" Language="de">Descr Supplement 0x540 DE</Text>
+                        <Text TextFormat="PlainText" Language="it">Descr Supplement 0x540 IT</Text>
+                    </Description>
+                </Supplement>
+
+                <Supplement InvType="EXTRA" InvCode="0x541" AddToBasicRateIndicator="true" MandatoryIndicator="false" ChargeTypeCode="18">
+                    <PrerequisiteInventory InvCode="1001001" InvType="ALPINEBITSDOW"/>
+                    <Description Name="title">
+                        <Text TextFormat="PlainText" Language="de">Title Supplement 0x541 DE</Text>
+                        <Text TextFormat="PlainText" Language="it">Title Supplement 0x541 IT</Text>
+
+                    </Description>
+                    <Description Name="intro">
+                        <Text TextFormat="PlainText" Language="de">Descr Supplement 0x541 DE</Text>
+                        <Text TextFormat="PlainText" Language="it">Descr Supplement 0x541 IT</Text>
+                    </Description>
+                </Supplement>
+
+                <!-- category peculiar setting -->
+                <Supplement InvType="EXTRA" InvCode="0x539" Amount="20" Start="2014-10-01" End="2014-10-11">
+                    <PrerequisiteInventory InvType="ROOMTYPE" InvCode="DZ"/>
+                </Supplement>
+                <Supplement InvType="EXTRA" InvCode="0x539" Amount="15" Start="2014-10-01" End="2014-10-11">
+                    <PrerequisiteInventory InvType="ROOMTYPE" InvCode="EZ"/>
+                </Supplement>
+
+                <!-- no peculiar supplement -->
+                <Supplement InvType="EXTRA" InvCode="0x540" Amount="15" Start="2014-10-01" End="2014-10-11" />
+
+                <!-- category peculiar setting -->
+                <Supplement InvType="EXTRA" InvCode="0x541" Amount="25" Start="2014-10-01" End="2014-10-11">
+                    <PrerequisiteInventory InvType="ROOMTYPE" InvCode="DZ"/>
+                </Supplement>
+                <Supplement InvType="EXTRA" InvCode="0x541" Amount="15" Start="2014-10-01" End="2014-10-11">
+                    <PrerequisiteInventory InvType="ROOMTYPE" InvCode="EZ"/>
+                </Supplement>
+
+            </Supplements>
+
+            <Offers>
+                <Offer>
+                    <OfferRules>
+                        <OfferRule>
+                            <Occupancy AgeQualifyingCode="10" MinAge="16"/>
+                            <Occupancy AgeQualifyingCode="8"/>
+                        </OfferRule>
+                    </OfferRules>
+                </Offer>
+            </Offers>
+
+            <Description Name="title">
+                <Text TextFormat="PlainText" Language="en">Lorem ipsum.</Text>
+                <Text TextFormat="PlainText" Language="it">Lorem ipsum.</Text>
+                <!-- more languages ... -->
+            </Description>
+
+            <Description Name="intro">
+                <Text TextFormat="PlainText" Language="en">Lorem ipsum dolor sit amet.</Text>
+                <Text TextFormat="PlainText" Language="it">Lorem ipsum dolor sit amet.</Text>
+                <!-- more languages ... -->
+            </Description>
+
+        </RatePlan>
+
+    </RatePlans>
+
+</OTA_HotelRatePlanNotifRQ>

--- a/files/schema-rng/alpinebits.rng
+++ b/files/schema-rng/alpinebits.rng
@@ -2107,18 +2107,30 @@
                 <rng:element name="Supplement">
 
                   <rng:optional>
-                    <rng:element name="PrerequisiteInventory">
-                      <rng:attribute name="InvCode">
-                        <rng:data type="string">
-                          <rng:param name="pattern">[01]{7}</rng:param>
-                        </rng:data>
-                      </rng:attribute>
-                      <rng:attribute name="InvType">
-                        <rng:choice>
-                          <rng:value>ALPINEBITSDOW</rng:value>
-                        </rng:choice>
-                      </rng:attribute>
-                    </rng:element>
+                    <rng:choice>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:data type="string">
+                              <rng:param name="pattern">[01]{7}</rng:param>
+                            </rng:data>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ALPINEBITSDOW</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ROOMTYPE</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                    </rng:choice>
                   </rng:optional>
 
                   <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->

--- a/files/schema-xsd/alpinebits.xsd
+++ b/files/schema-xsd/alpinebits.xsd
@@ -1850,26 +1850,21 @@
                         <xs:element name="Supplement" maxOccurs="unbounded">
                           <xs:complexType>
                             <xs:sequence>
-
-                              <xs:element name="PrerequisiteInventory" minOccurs="0" maxOccurs="1">
-                                <xs:complexType>
-                                    <xs:attribute name="InvCode" use="required">
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:pattern value="[01]{7}"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:attribute>
-                                    <xs:attribute name="InvType" use="required">
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="ALPINEBITSDOW"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:attribute>
-                                </xs:complexType>
-                              </xs:element>
-
+                              <xs:choice>
+                                <xs:element name="PrerequisiteInventory" minOccurs="0" maxOccurs="1">
+                                  <xs:complexType>
+                                      <xs:attribute name="InvCode" use="required" type="def_nonempty_string"/>
+                                      <xs:attribute name="InvType" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="ALPINEBITSDOW"/>
+                                            <xs:enumeration value="ROOMTYPE"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:choice>
                               <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,5} -->
                       
                               <xs:element name="Description" minOccurs="0" maxOccurs="5">


### PR DESCRIPTION
It seems that we're missing the PrerequisiteInventory sub-element for date depending supplements:

RC2 pag 55 (date depending section):

"An optional PrerequisiteInventory sub-element with the mandatory InvType attribute set to ROOMTYPE can be used to make supplements available [...]. The mandatory InvCode attribute can be used to identify the room category the supplement applies to."

I've modified xsd and rng and added an xml document example on samples-contrib folder
